### PR TITLE
reorder two lines

### DIFF
--- a/backbone.poller.js
+++ b/backbone.poller.js
@@ -85,8 +85,8 @@
                 }
             },
             error: function(){
-                poller.trigger('error', poller.model);
                 poller.stop({silent: true});
+                poller.trigger('error', poller.model);
             }
         });
         poller.trigger('fetch', poller.model);


### PR DESCRIPTION
Hello @uzikilon.
This patch allow restart the poller after fetch error.

For example.

``` javascript
var opts = {
  autostart: true,
  error: function() {
    this.start();
  }
};
PollingManager.getPoller(mymodel, opts);
```
