### PR TITLE
Only fetch if run condition is met.

### DIFF
--- a/backbone.poller.js
+++ b/backbone.poller.js
@@ -165,8 +165,10 @@ Backbone Poller may be freely distributed under the MIT license.
         poller.trigger('error', poller.model, xhr);
       }
     });
-    poller.trigger('fetch', poller.model);
-    poller.xhr = poller.model.fetch(options);
+    if (poller.options.condition(poller.model) === true) {
+        poller.trigger('fetch', poller.model);
+        poller.xhr = poller.model.fetch(options);
+    }
   }
 
   function delayedRun(poller) {


### PR DESCRIPTION
When polling with the delayed option, if the condition to fetch changes between a fetch being queued to run (delay) and run being executed, the result is a fetch being made - which is not desirable (as the conditions have changed)
