### PR TITLE
Publish as a bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "backbone-poller",
+  "version": "0.2.8",
+  "homepage": "https://github.com/uzikilon/backbone-poller",
+  "description": "Backbone poller is a simple utility that allows polling on any backbone model or collection.",
+  "main": "backbone.poller.js",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test"
+  ]
+}


### PR DESCRIPTION
Would be great to be published as a bower package.
As you may know, you need to run the command once, and then just pushing git tag is fine to bump up.

```
$ bower register backbone-poller git@github.com:uzikilon/backbone-poller.git
```
