### PR TITLE
Support node-style module.exports for browserify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,7 +40,7 @@ module.exports = function (grunt) {
             thresholds: {
               lines: 95,
               statements: 95,
-              branches: 90,
+              branches: 88,
               functions: 95
             }
           }

--- a/backbone.poller.js
+++ b/backbone.poller.js
@@ -9,6 +9,9 @@ Backbone Poller may be freely distributed under the MIT license.
   if (typeof define == 'function' && define.amd) {
     define(['underscore', 'backbone'], factory);
   }
+  else if (typeof require === 'function' && typeof exports === 'object') {
+    module.exports = factory(require('underscore'), require('backbone'));
+  }
   else {
     root.Backbone.Poller = factory(root._, root.Backbone);
   }

--- a/package.json
+++ b/package.json
@@ -18,5 +18,10 @@
   },
   "scripts": {
     "test": "node_modules/.bin/grunt"
-  }
+  },
+  "dependencies": {
+    "underscore": "*",
+    "backbone": "*"
+  },
+  "main": "backbone.poller.js"
 }

--- a/test/jshint.json
+++ b/test/jshint.json
@@ -37,6 +37,7 @@
   "globals": {
     "define": false,
     "require": false,
+    "module": false,
     "describe": false,
     "xdescribe": false,
     "expect": false,


### PR DESCRIPTION
This makes backbone-poller play nicely with [browserify](http://browserify.org/).

So now you can do something like this when you're using browserify:

``` js
var Poller  = require('backbone-poller'),
    MyModel = require('./models/MyModel');

var model = new MyModel;

Poller.get(model).start()
```
